### PR TITLE
Remove verbosity flag for untar script

### DIFF
--- a/resources/scripts/unTar.sh
+++ b/resources/scripts/unTar.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-tar -xhjvf /tmp/app.tar.tbz
+tar -xhjf /tmp/app.tar.tbz


### PR DESCRIPTION
Some logs get overwhelmed by the number of files that are in the tarball. 