### PR TITLE
Prevent root ownership

### DIFF
--- a/resources/scripts/unTar.sh
+++ b/resources/scripts/unTar.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
+
+# The user's UID and GID from outside the docker container is expected to be passed in as parameters.
+# Falls back to the "node" user and group.
+REAL_UID=$1
+if [ "$REAL_UID" = "" ]; then
+  REAL_UID="node"
+fi
+REAL_GID=$2
+if [ "$REAL_GID" = "" ]; then
+  REAL_GID="node"
+fi
+
 tar -xhjf /tmp/app.tar.tbz --checkpoint=.500
-chown -R node .
-chgrp -R node .
+
+# This will cause the untarred directory to not be owned by the root user.
+chown -R $REAL_UID .
+chgrp -R $REAL_GID .
 chmod -R g+rwX .

--- a/resources/scripts/unTar.sh
+++ b/resources/scripts/unTar.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
 tar -xhjf /tmp/app.tar.tbz --checkpoint=.500
+chown -R node .
+chgrp -R node .
+chmod -R g+rwX .


### PR DESCRIPTION
The unTar.sh script is run inside the skipdaddy/install-ab:developer_v2 container. It runs as root, so the resulting files created are owned by root, and that creates problems. This change is meant to fix that.

`node` is the only user account within the install-ab:developer_v2 image. The entire untarred `app` tree should now become owned by this user within the container. Going through the Docker bind mount, the directory tree will become owned by a normal user on the host machine outside the container. The same goes for the group ownership. This solves the root ownership issue.

However, there is no guarantee that the user and group will match the ones from the actual user. It will most likely just get mapped to the first regular user and group that were added on that server. Still better than root, I think. The first group added on most (all?) of our servers is typically `appdev` or `digiserve`, so that should probably be good enough.